### PR TITLE
Added port and volume settings to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,12 @@ ENV ARCHIVA_BASE /var/archiva
 ### expose contextPath as environment variable
 ENV ARCHIVA_CONTEXT_PATH /
 
+### expose archiva port
+EXPOSE 8080
+
+### expose archiva volume
+VOLUME ["/var/archiva"]
+
 ### get our custom run script
 ADD run-archiva /opt/archiva/run-archiva
 


### PR DESCRIPTION
Exposed port 8080
Added /var/archiva volume

These settings provide a few benefits:
1. When using the image in Docker's Kitematic, the port and volume will be shown so that they can be mapped to appropriate host ports/volumes.
2. the /var/archiva data will persist between restarts, even if the -v command is not used to mount it to an explicit volume. In this case it will live in someplace such as /mnt/{sdaN}/var/lib/docker/volumes
