### PR TITLE
Archiva download improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,12 @@ RUN apt-get update \
 
 ### download archiva binary
 WORKDIR /opt/archiva
-RUN wget http://apache.spinellicreations.com/archiva/2.2.0/binaries/apache-archiva-2.2.0-bin.tar.gz \
-    && tar -xzf apache-archiva-2.2.0-bin.tar.gz
+RUN wget "$(curl 'http://www.apache.org/dyn/closer.cgi' | grep -o '<strong>[^<]*</strong>' | sed 's/<[^>]*>//g' | head -1)archiva/2.2.0/binaries/apache-archiva-2.2.0-bin.tar.gz" && \
+    md5sum apache-archiva-2.2.0-bin.tar.gz > apache-archiva-2.2.0-bin.tar.gz.my.md5 && \
+    wget https://www.apache.org/dist/archiva/2.2.0/binaries/apache-archiva-2.2.0-bin.tar.gz.md5 && \
+    cmp -s apache-archiva-2.2.0-bin.tar.gz.my.md5 apache-archiva-2.2.0-bin.tar.gz.md5 && \
+    tar -xzf apache-archiva-2.2.0-bin.tar.gz && \
+    rm apache-archiva-2.2.0-bin.tar.gz
 
 ### separate config and data dirs from binary
 ENV ARCHIVA_BASE /var/archiva

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN wget "$(curl 'http://www.apache.org/dyn/closer.cgi' | grep -o '<strong>[^<]*
     wget https://www.apache.org/dist/archiva/2.2.0/binaries/apache-archiva-2.2.0-bin.tar.gz.md5 && \
     cmp -s apache-archiva-2.2.0-bin.tar.gz.my.md5 apache-archiva-2.2.0-bin.tar.gz.md5 && \
     tar -xzf apache-archiva-2.2.0-bin.tar.gz && \
-    rm apache-archiva-2.2.0-bin.tar.gz
+    rm apache-archiva-2.2.0-bin.tar.gz*
 
 ### separate config and data dirs from binary
 ENV ARCHIVA_BASE /var/archiva


### PR DESCRIPTION
Made the wget choose a strong mirror relative to the deployed location
Verified the md5 hash
Cleaned up tar and hash files after use
