### PR TITLE
Upgrade to Archiva 2.2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,13 @@ RUN apt-get update \
     && apt-get autoclean \
     && apt-get autoremove
 
-### download archiva binary
+### Download Archiva 2.2.3, verify md5 checksum, unzip.
 WORKDIR /opt/archiva
-RUN wget "$(curl 'http://www.apache.org/dyn/closer.cgi' | grep -o '<strong>[^<]*</strong>' | sed 's/<[^>]*>//g' | head -1)archiva/2.2.0/binaries/apache-archiva-2.2.0-bin.tar.gz" && \
-    md5sum apache-archiva-2.2.0-bin.tar.gz > apache-archiva-2.2.0-bin.tar.gz.my.md5 && \
-    wget https://www.apache.org/dist/archiva/2.2.0/binaries/apache-archiva-2.2.0-bin.tar.gz.md5 && \
-    cmp -s apache-archiva-2.2.0-bin.tar.gz.my.md5 apache-archiva-2.2.0-bin.tar.gz.md5 && \
-    tar -xzf apache-archiva-2.2.0-bin.tar.gz && \
-    rm apache-archiva-2.2.0-bin.tar.gz*
+RUN wget https://www.apache.org/dist/archiva/2.2.3/binaries/apache-archiva-2.2.3-bin.tar.gz && \
+    wget https://www.apache.org/dist/archiva/2.2.3/binaries/apache-archiva-2.2.3-bin.tar.gz.md5 && \
+    md5sum --check apache-archiva-2.2.3-bin.tar.gz.md5 && \
+    tar -xzf apache-archiva-2.2.3-bin.tar.gz && \
+    rm apache-archiva-2.2.3-bin.tar.gz*
 
 ### separate config and data dirs from binary
 ENV ARCHIVA_BASE /var/archiva

--- a/run-archiva
+++ b/run-archiva
@@ -2,7 +2,7 @@
 
 # apply ARCHIVA_CONTEXT_PATH
 sed -i "s|name=\"contextPath\">/<|name=\"contextPath\">$ARCHIVA_CONTEXT_PATH<|g" \
-  /opt/archiva/apache-archiva-2.2.0/contexts/archiva.xml
+  /opt/archiva/apache-archiva-2.2.3/contexts/archiva.xml
 
 # create config and data dirs if needed
 # allows archiva to start fresh, or have these dirs mounted in from the host
@@ -19,8 +19,8 @@ if [ ! -d /var/archiva/temp ]; then
 fi
 
 if [ ! -d /var/archiva/conf ]; then
-  cp -r /opt/archiva/apache-archiva-2.2.0/conf /var/archiva
+  cp -r /opt/archiva/apache-archiva-2.2.3/conf /var/archiva
 fi
 
 # start archiva in console mode to keep in foreground
-/opt/archiva/apache-archiva-2.2.0/bin/archiva console
+/opt/archiva/apache-archiva-2.2.3/bin/archiva console


### PR DESCRIPTION
The 2.2.0-bin URL on master no longer exists:

```
 ---> Using cache
 ---> 3b97f1148b82
Step 5/11 : RUN wget "$(curl 'http://www.apache.org/dyn/closer.cgi' | grep -o '<strong>[^<]*</strong>' | sed 's/<[^>]*>//g' | head -1)archiva/2.2.0/binaries/apache-archiva-2.2.0-bin.tar.gz" &&     md5sum apache-archiva-2.2.0-bin.tar.gz > apache-archiva-2.2.0-bin.tar.gz.my.md5 &&     wget https://www.apache.org/dist/archiva/2.2.0/binaries/apache-archiva-2.2.0-bin.tar.gz.md5 &&     cmp -s apache-archiva-2.2.0-bin.tar.gz.my.md5 apache-archiva-2.2.0-bin.tar.gz.md5 &&     tar -xzf apache-archiva-2.2.0-bin.tar.gz &&     rm apache-archiva-2.2.0-bin.tar.gz*
 ---> Running in 8eb2160574a3
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 19454    0 19454    0     0  16977      0 --:--:--  0:00:01 --:--:-- 16975
--2017-12-22 21:56:26--  http://apache.claz.org/archiva/2.2.0/binaries/apache-archiva-2.2.0-bin.tar.gz
Resolving apache.claz.org (apache.claz.org)... 74.63.227.45
Connecting to apache.claz.org (apache.claz.org)|74.63.227.45|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2017-12-22 21:56:26 ERROR 404: Not Found.

The command '/bin/sh -c wget "$(curl 'http://www.apache.org/dyn/closer.cgi' | grep -o '<strong>[^<]*</strong>' | sed 's/<[^>]*>//g' | head -1)archiva/2.2.0/binaries/apache-archiva-2.2.0-bin.tar.gz" &&     md5sum apache-archiva-2.2.0-bin.tar.gz > apache-archiva-2.2.0-bin.tar.gz.my.md5 &&     wget https://www.apache.org/dist/archiva/2.2.0/binaries/apache-archiva-2.2.0-bin.tar.gz.md5 &&     cmp -s apache-archiva-2.2.0-bin.tar.gz.my.md5 apache-archiva-2.2.0-bin.tar.gz.md5 &&     tar -xzf apache-archiva-2.2.0-bin.tar.gz &&     rm apache-archiva-2.2.0-bin.tar.gz*' returned a non-zero code: 8
```

This PR upgrades to 2.2.3, fixing the build.